### PR TITLE
#167193656 Add User Signin feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Build Status](https://travis-ci.org/dinorhythms/WayFarer.svg?branch=develop)](https://travis-ci.org/dinorhythms/WayFarer)

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -53,6 +53,45 @@ class authController {
 
     }
 
+    static async signIn(req,res){
+        const { email, password } = req.body;
+        if(!email || !password ){
+            return res.status(400).json({status:'error', data: "All fields are required"})
+        }
+
+        //check if user exists
+        const user = await userModel.getUserByEmail(email);
+        if(!user) return res.status(400).json({status:'error', data: "User does not exist"})
+        
+        //validate the password
+        bcrypt.compare(password, user.password)
+            .then(isMatch => {
+                if(!isMatch) return res.status(400).json({status:'error', data: "Invalid Credentials"})
+                
+                jwt.sign(
+                    { id: user.id },
+                    process.env.TOKEN_SECRET,
+                    { expiresIn: 3600 },
+                    (err, token) => {
+                        if(err) throw err;
+                        res.status(200).json({
+                            status: 'success',
+                            data: {
+                                user_id: user.id,
+                                is_admin: user.is_admin,
+                                token: token,
+                                email: user.email,
+                                first_name: user.first_name,
+                                last_name: user.last_name
+                            }
+                        })
+                    }
+                )
+
+            })
+
+    }
+
 }
 
 export default authController;

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -9,4 +9,9 @@ const auth = express.Router();
 // @access  Public
 auth.post('/signup', authController.signUp);
 
+// @route   POST api/v1/auth/signin
+// @desc    User signin
+// @access  Public
+auth.post('/signin', authController.signIn);
+
 export default auth;

--- a/src/test/users.spec.js
+++ b/src/test/users.spec.js
@@ -24,7 +24,8 @@ before(function (done) {
   done();
 });
 
-describe('Test User Registration POST api/v1/auth/signup', function () {
+describe('User Signup POST api/v1/auth/signup', function () {
+  this.timeout(10000)
   describe('POST sign up successful', function () {
     it('Should sign up successful', function (done) {
       request
@@ -88,6 +89,78 @@ describe('Test User Registration POST api/v1/auth/signup', function () {
           res.body.status.should.be.a('string');
           res.body.status.should.be.equal('error');
           res.body.data.should.be.equal('All fields are required');
+          done();
+        });
+    });
+  });
+
+});
+
+describe('User Signin POST api/v1/auth/signin', function () {
+  this.timeout(10000)
+  describe('POST signin successfully', function () {
+    it('Should signin successfully', function (done) {
+      request
+        .post('/api/v1/auth/signin')
+        .set('Accept', 'application/json')
+        .send({ 'email': 'ola@gmail.com', 'password': 'password' })
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err);
+          res.should.have.status(200);
+          res.should.be.json;
+          res.body.should.be.a('object');
+          res.body.should.have.property('status');
+          res.body.should.have.property('data');
+          res.body.status.should.be.a('string');
+          res.body.data.should.be.a('object');
+          res.body.data.should.have.property('user_id');
+          res.body.data.should.have.property('is_admin');
+          res.body.data.should.have.property('email');
+          res.body.data.should.have.property('first_name');
+          res.body.data.should.have.property('last_name');
+          res.body.data.should.have.property('token');
+          done();
+        });
+    });
+  });
+
+  describe('POST check user existence api/v1/auth/signin', function () {
+    it('should return user does not exist', function (done) {
+      request
+        .post('/api/v1/auth/signin')
+        .set('Accept', 'application/json')
+        .send({ 'email': 'larry@gmail.com', 'password': 'password' })
+        .expect(400)
+        .end((err, res) => {
+          res.should.have.status(400);
+          res.should.be.json;
+          res.body.should.be.a('object');
+          res.body.should.have.property('status');
+          res.body.status.should.be.a('string');
+          res.body.status.should.be.equal('error');
+          res.body.data.should.be.equal('User does not exist');
+          done();
+        });
+    });
+  });
+
+  describe('POST check wrong password api/v1/auth/signin', function () {
+    it('should return invalid credential', function (done) {
+      request
+        .post('/api/v1/auth/signin')
+        .set('Accept', 'application/json')
+        .send({ 'email': 'ola@gmail.com', 'password': 'passwordy' })
+        .expect(400)
+        .end((err, res) => {
+          res.should.have.status(400);
+          res.should.be.json;
+          res.body.should.be.a('object');
+          res.body.should.have.property('status');
+          res.body.status.should.be.a('string');
+          res.body.status.should.be.equal('error');
+          res.body.data.should.be.equal('Invalid Credentials');
           done();
         });
     });


### PR DESCRIPTION
## Registered users can easily signin with email and password

#### What does this PR do?
Users can signin to the backend using the route POST /api/v1/auth/signin.
It generated a token using jwtwebtoken and responds back users details with token
#### Description of Task to be completed?
- create signin route
- create signin method in controller
- check password with bcryptjs
- generate token with jwtwebtoken
- create sign test with mocha
#### How should this be manually tested?
POST /api/v1/auth/signin
HEADER Content/type 'application/json';
fields : { 'email': 'ola@gmail.com', 'password': 'password' }
#### What are the relevant pivotal tracker stories?
[#167193656](https://www.pivotaltracker.com/story/show/167193656)
[(Finishes) #167193656]